### PR TITLE
Fix types field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "exports": "./dist/index.js",
   "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/",
     "CHANGELOG.md"


### PR DESCRIPTION
The types field is `index.d.js` instead of `index.d.ts`, which causes a warning in the editor when importing the package and no type inference.

as-is
![error1](https://github.com/joshuajaco/find-workspaces/assets/79135734/e89f40c0-fd7d-451c-9bd3-4f58446b1557)
![error2](https://github.com/joshuajaco/find-workspaces/assets/79135734/6900d323-bb8b-43b7-9dfd-4273c8499a9c)



to-be
![tobe1](https://github.com/joshuajaco/find-workspaces/assets/79135734/fa66bef7-0e3a-4380-b4cd-8752f0b7136f)
![tobe2](https://github.com/joshuajaco/find-workspaces/assets/79135734/4a63423e-5c50-45af-9342-20fac2ebcfd3)

